### PR TITLE
Pinning covalent to 0.177.0.post1.dev0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+
+### Changed
+
+- Updated requirements.txt to pin covalent to version 0.177.0.post1.dev0
+
 ### Tests
 
 - Fixed config manager related test which broke as a result of changes in covalent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 asyncssh>=2.10.1
-git+https://github.com/AgnostiqHQ/covalent.git@develop#egg=covalent
+covalent==0.177.0.post1.dev0


### PR DESCRIPTION
Pinning covalent to version 0.177.0.post1.dev0

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
