### PR TITLE
Fixed get_status to correctly assert if remote result file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed get_status to correctly assert if remote result file exists
+
 ## [0.13.0] - 2022-09-15
 
 

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -361,7 +361,7 @@ class SSHExecutor(RemoteExecutor):
         check_result_file = await conn.run(cmd)
         client_out = check_result_file.stdout
 
-        return client_out.strip() != remote_result_file
+        return client_out.strip() == remote_result_file
 
     async def _poll_task(
         self, conn: asyncssh.SSHClientConnection, remote_result_file: str, retries: int = 5


### PR DESCRIPTION
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
