### PR TITLE
workdir and create_unique_workdir for ssh plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,6 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
-        language_version: python3.8
 
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Ability to specify a `workdir` along with `create_unique_workdir` option for each electron / node.
+- Ability to specify a `remote_workdir` along with `create_unique_workdir` option for each electron / node.
 
 ## [0.20.0] - 2022-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Ability to specify a `workdir` along with `create_unique_workdir` option for each electron / node.
+
 ## [0.20.0] - 2022-12-15
 
 ### Changed

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -35,7 +35,7 @@ from covalent._shared_files import logger
 from covalent._shared_files.config import get_config
 from covalent.executor.executor_plugins.remote_executor import RemoteExecutor
 
-executor_plugin_name = "SSHExecutor"
+EXECUTOR_PLUGIN_NAME = "SSHExecutor"
 
 app_log = logger.app_log
 log_stack_info = logger.log_stack_info

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -26,7 +26,7 @@ import asyncio
 import os
 import socket
 from pathlib import Path
-from typing import Any, Callable, Coroutine, Dict, Tuple, Union, Optional
+from typing import Any, Callable, Coroutine, Dict, Optional, Tuple, Union
 
 import asyncssh
 import cloudpickle as pickle

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -519,7 +519,9 @@ class SSHExecutor(RemoteExecutor):
             remote_function_file,
             remote_script_file,
             remote_result_file,
-        ) = self._write_function_files(operation_id, function, args, kwargs, current_remote_workdir)
+        ) = self._write_function_files(
+            operation_id, function, args, kwargs, current_remote_workdir
+        )
 
         app_log.debug("Copying function file to remote machine...")
         await self._upload_task(

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -49,7 +49,7 @@ _EXECUTOR_PLUGIN_DEFAULTS = {
     "conda_env": "",
     "remote_cache": ".cache/covalent",
     "run_local_on_ssh_fail": False,
-    "remote_workdir": ".cache/covalent/remote_workdir",
+    "remote_workdir": "covalent-workdir",
     "create_unique_workdir": False,
 }
 
@@ -108,7 +108,11 @@ class SSHExecutor(RemoteExecutor):
         self.run_local_on_ssh_fail = run_local_on_ssh_fail
 
         self.remote_workdir = remote_workdir or get_config("executors.ssh.remote_workdir")
-        self.create_unique_workdir = create_unique_workdir or get_config("executors.ssh.create_unique_workdir")
+        self.create_unique_workdir = (
+            get_config("executors.ssh.create_unique_workdir")
+            if create_unique_workdir is None
+            else create_unique_workdir
+        )
 
         self.do_cleanup = do_cleanup
 
@@ -139,7 +143,9 @@ class SSHExecutor(RemoteExecutor):
         operation_id = f"{dispatch_id}_{node_id}"
 
         if self.create_unique_workdir:
-            current_remote_workdir = os.path.join(self.remote_workdir, dispatch_id, f"node_{node_id}")
+            current_remote_workdir = os.path.join(
+                self.remote_workdir, dispatch_id, f"node_{node_id}"
+            )
         else:
             current_remote_workdir = self.remote_workdir
 

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -36,6 +36,8 @@ config_data = {
     "executors.ssh.remote_cache": "/home/centos",
     "executors.ssh.python_path": "python3.8",
     "executors.ssh.conda_env": "py-3.8",
+    "executors.ssh.remote_workdir": "covalent-workdir",
+    "executors.ssh.create_unique_workdir": False,
 }
 
 
@@ -63,6 +65,8 @@ def test_init(mocker, tmp_path):
     assert executor.remote_cache == config_data["executors.ssh.remote_cache"]
     assert executor.python_path == config_data["executors.ssh.python_path"]
     assert executor.run_local_on_ssh_fail is False
+    assert executor.remote_workdir == config_data["executors.ssh.remote_workdir"]
+    assert executor.create_unique_workdir is False
     assert executor.do_cleanup is True
 
 

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -156,8 +156,7 @@ def test_file_writes(mocker):
     @patch("builtins.open", new_callable=mock_open())
     def write_files(mock):
         return executor._write_function_files(
-            dispatch_id,
-            task_id,
+            operation_id,
             simple_task,
             [5],
             {},

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -57,6 +57,7 @@ def test_init(mocker, tmp_path):
         username="user",
         hostname="host",
         ssh_key_file=str(key_path),
+        create_unique_workdir=True,
     )
 
     assert executor.username == "user"
@@ -66,7 +67,7 @@ def test_init(mocker, tmp_path):
     assert executor.python_path == config_data["executors.ssh.python_path"]
     assert executor.run_local_on_ssh_fail is False
     assert executor.remote_workdir == config_data["executors.ssh.remote_workdir"]
-    assert executor.create_unique_workdir is False
+    assert executor.create_unique_workdir is True
     assert executor.do_cleanup is True
 
 

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -149,13 +149,15 @@ def test_file_writes(mocker):
     def simple_task(x):
         return x
 
-    operation_id = "dispatchid_taskid"
+    dispatch_id = "dispatchid"
+    task_id = "taskid"
+    operation_id = f"{dispatch_id}_{task_id}"
 
     @patch("builtins.open", new_callable=mock_open())
     def write_files(mock):
         return executor._write_function_files(
-            "dispatchid",
-            "taskid",
+            dispatch_id,
+            task_id,
             simple_task,
             [5],
             {},

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -150,7 +150,8 @@ def test_file_writes(mocker):
     @patch("builtins.open", new_callable=mock_open())
     def write_files(mock):
         return executor._write_function_files(
-            operation_id,
+            "dispatchid",
+            "taskid",
             simple_task,
             [5],
             {},


### PR DESCRIPTION
Closes https://github.com/AgnostiqHQ/covalent-ssh-plugin/issues/64

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

~~This is a WIP since we probably need to do the following:~~

~~- Have another variable corresponding to `remote_workdir` but for local machine i.e. not on the remote server~~
~~- Sync the `remote_workdir` contents into `workdir` (for local) if we do the above...~~

~~But I could appreciate some initial thoughts...~~

CC: @arosen93