### PR TITLE
Expand connection retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Expand connection retry logic to cover more cases
-- Move exec script into a separate file 
+- Move exec script into a separate file
 
 ## [0.23.0] - 2023-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Expand connection retry logic to cover more cases
+- Move exec script into a separate file 
+
 ## [0.23.0] - 2023-10-20
 
 ### Changed

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  # This script is read into a string and formatted. Never executed directly.
+  - covalent_ssh_plugin/exec.py

--- a/covalent_ssh_plugin/exec.py
+++ b/covalent_ssh_plugin/exec.py
@@ -1,0 +1,45 @@
+"""
+Load task `fn` from pickle. Run it. Save the result.
+"""
+import os
+import sys
+from pathlib import Path
+
+result = None
+exception = None
+
+# NOTE: Paths must be substituted-in here by the executor.
+remote_result_file = Path('{remote_result_file}').resolve()
+remote_function_file = Path('{remote_function_file}').resolve()
+current_remote_workdir = Path('{current_remote_workdir}').resolve()
+
+try:
+    # Make sure cloudpickle is available.
+    import cloudpickle as pickle
+except Exception as e:
+    import pickle
+    with open(remote_result_file, 'wb') as f_out:
+        pickle.dump((None, e), f_out)
+        sys.exit(1)  # Error.
+
+current_dir = os.getcwd()
+
+# Read the function object and arguments from pickle file.
+with open(remote_function_file, 'rb') as f_in:
+    fn, args, kwargs = pickle.load(f_in)
+
+try:
+    # Execute the task `fn` inside the remote workdir.
+    current_remote_workdir.mkdir(parents=True, exist_ok=True)
+    os.chdir(current_remote_workdir)
+
+    result = fn(*args, **kwargs)
+
+except Exception as e:
+    exception = e
+finally:
+    os.chdir(current_dir)
+
+# Save the result to pickle file.
+with open(remote_result_file, 'wb') as f_out:
+    pickle.dump((result, exception), f_out)

--- a/covalent_ssh_plugin/exec.py
+++ b/covalent_ssh_plugin/exec.py
@@ -9,23 +9,24 @@ result = None
 exception = None
 
 # NOTE: Paths must be substituted-in here by the executor.
-remote_result_file = Path('{remote_result_file}').resolve()
-remote_function_file = Path('{remote_function_file}').resolve()
-current_remote_workdir = Path('{current_remote_workdir}').resolve()
+remote_result_file = Path("{remote_result_file}").resolve()
+remote_function_file = Path("{remote_function_file}").resolve()
+current_remote_workdir = Path("{current_remote_workdir}").resolve()
 
 try:
     # Make sure cloudpickle is available.
     import cloudpickle as pickle
 except Exception as e:
     import pickle
-    with open(remote_result_file, 'wb') as f_out:
+
+    with open(remote_result_file, "wb") as f_out:
         pickle.dump((None, e), f_out)
         sys.exit(1)  # Error.
 
 current_dir = os.getcwd()
 
 # Read the function object and arguments from pickle file.
-with open(remote_function_file, 'rb') as f_in:
+with open(remote_function_file, "rb") as f_in:
     fn, args, kwargs = pickle.load(f_in)
 
 try:
@@ -41,5 +42,5 @@ finally:
     os.chdir(current_dir)
 
 # Save the result to pickle file.
-with open(remote_result_file, 'wb') as f_out:
+with open(remote_result_file, "wb") as f_out:
     pickle.dump((result, exception), f_out)

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -224,14 +224,14 @@ class SSHExecutor(RemoteExecutor):
             raise RuntimeError(message)
 
         try:
-            conn = await self._retry_client_connect()
+            conn = await self._attempt_client_connect()
             ssh_success = conn is not None
         except (socket.gaierror, ValueError, TimeoutError) as e:
             app_log.error(e)
 
         return ssh_success, conn
 
-    async def _retry_client_connect(self) -> Optional[asyncssh.SSHClientConnection]:
+    async def _attempt_client_connect(self) -> Optional[asyncssh.SSHClientConnection]:
         """
         Helper function that catches specific errors and retries connecting to the remote host.
 

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -277,6 +277,7 @@ class SSHExecutor(RemoteExecutor):
             finally:
                 attempt += 1
 
+        # Failed to connect to client.
         return None
 
     async def cleanup(

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -72,7 +72,6 @@ class SSHExecutor(RemoteExecutor):
         retry_wait_time: Time to wait (in seconds) before reattempting connection.
     """
 
-
     def __init__(
         self,
         username: str,

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -222,7 +222,7 @@ class SSHExecutor(RemoteExecutor):
 
         try:
             conn = await self._retry_client_connect(max_attempts=5)
-            ssh_success = (conn is not None)
+            ssh_success = conn is not None
         except (socket.gaierror, ValueError, TimeoutError) as e:
             app_log.error(e)
 

--- a/covalent_ssh_plugin/ssh.py
+++ b/covalent_ssh_plugin/ssh.py
@@ -66,12 +66,12 @@ class SSHExecutor(RemoteExecutor):
             then the execution is run on the local machine.
         remote_workdir: The working directory on the remote server used for storing files produced from workflows.
         create_unique_workdir: Whether to create unique sub-directories for each node / task / electron.
-        poll_freq: Number of seconds to wait for before retrying the result poll
-        do_cleanup: Whether to delete all the intermediate files or not
+        poll_freq: Number of seconds to wait for before retrying the result poll.
+        do_cleanup: Delete all the intermediate files or not if True.
+        max_connection_attempts: Maximum number of attempts to establish SSH connection.
+        retry_wait_time: Time to wait (in seconds) before reattempting connection.
     """
 
-    max_connection_attempts = 5
-    retry_wait_time = 5  # seconds
 
     def __init__(
         self,
@@ -88,6 +88,8 @@ class SSHExecutor(RemoteExecutor):
         poll_freq: int = 15,
         do_cleanup: bool = True,
         retry_connect: bool = True,
+        max_connection_attempts: int = 5,
+        retry_wait_time: int = 5,
     ) -> None:
 
         remote_cache = (
@@ -116,6 +118,8 @@ class SSHExecutor(RemoteExecutor):
 
         self.do_cleanup = do_cleanup
         self.retry_connect = retry_connect
+        self.max_connection_attempts = max_connection_attempts
+        self.retry_wait_time = retry_wait_time
 
         ssh_key_file = ssh_key_file or get_config("executors.ssh.ssh_key_file")
         self.ssh_key_file = str(Path(ssh_key_file).expanduser().resolve())

--- a/tests/functional_tests/basic_workflow_test.py
+++ b/tests/functional_tests/basic_workflow_test.py
@@ -33,17 +33,11 @@ def test_basic_workflow():
 def test_basic_workflow_failure():
     @ct.electron(executor="ssh")
     def join_words(a, b):
-        return ", ".join([a, b])
-
-    @ct.electron
-    def excitement(a):
-        raise Exception("Something went wrong!")
-        # return f"{a}!"
+        raise Exception(f"{', '.join([a, b])} -- but something went wrong!")
 
     @ct.lattice
     def basic_workflow_that_will_fail(a, b):
-        phrase = join_words(a, b)
-        return excitement(phrase)
+        return join_words(a, b)
 
     # Dispatch the workflow
     dispatch_id = ct.dispatch(basic_workflow_that_will_fail)("Hello", "World")

--- a/tests/functional_tests/basic_workflow_test.py
+++ b/tests/functional_tests/basic_workflow_test.py
@@ -27,3 +27,29 @@ def test_basic_workflow():
     print(result)
 
     assert status == str(ct.status.COMPLETED)
+
+
+@pytest.mark.functional_tests
+def test_basic_workflow_failure():
+    @ct.electron(executor="ssh")
+    def join_words(a, b):
+        return ", ".join([a, b])
+
+    @ct.electron
+    def excitement(a):
+        raise Exception("Something went wrong!")
+        # return f"{a}!"
+
+    @ct.lattice
+    def basic_workflow_that_will_fail(a, b):
+        phrase = join_words(a, b)
+        return excitement(phrase)
+
+    # Dispatch the workflow
+    dispatch_id = ct.dispatch(basic_workflow_that_will_fail)("Hello", "World")
+    result = ct.get_result(dispatch_id=dispatch_id, wait=True)
+    status = str(result.status)
+
+    print(result)
+
+    assert status == str(ct.status.FAILED)

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -154,6 +154,7 @@ async def test_current_remote_workdir(mocker):
     async def mock_submit_task(mock_conn, file):
         ret = MagicMock()
         ret.stderr = ""
+        ret.exit_status = 0
         return ret
 
     mocker.patch("covalent_ssh_plugin.ssh.get_config", side_effect=get_config_mock)

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -121,7 +121,7 @@ async def test_failed_task_handling(mocker):
         fake_proc = namedtuple("fake_proc", ["stdout", "stderr"])
 
         async def run(self, *_):
-            return _FakeConn.fake_proc("Python 3.8", '')
+            return _FakeConn.fake_proc("Python 3.8", "")
 
         async def wait_closed(self):
             return True
@@ -136,7 +136,9 @@ async def test_failed_task_handling(mocker):
     mocker.patch("covalent_ssh_plugin.ssh.get_config", side_effect=get_config_mock)
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor._validate_credentials", return_value=True)
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor._client_connect", return_value=(True, _conn))
-    mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor._write_function_files", return_value=[''] * 5)
+    mocker.patch(
+        "covalent_ssh_plugin.ssh.SSHExecutor._write_function_files", return_value=[""] * 5
+    )
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor._upload_task", return_value=True)
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor.submit_task", return_value=_result)
 

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -111,13 +111,13 @@ async def test_on_ssh_fail(mocker):
 
 
 @pytest.mark.asyncio
-async def test_failed_task_handling(mocker):
-    """Test error handling after failure of submit_task."""
+async def test_nonzero_exit_status(mocker):
+    """Test handling nonzero exit status from 'run task' command on remote."""
 
     from collections import namedtuple
 
+    # Stand-in for the ssh connection object.
     class _FakeConn:
-
         fake_proc = namedtuple("fake_proc", ["stdout", "stderr"])
 
         async def run(self, *_):
@@ -126,13 +126,16 @@ async def test_failed_task_handling(mocker):
         async def wait_closed(self):
             return True
 
-    class _FakeResult:
-        stderr = "Fake error from `test_failed_task_handling`."
-        exit_status = 1
+    # Stand-in for the `run` command result.
+    class _FakeResultFailed:
+        stderr = "Fake error message"
+        exit_status = 1  # <--- This is the important part.
 
+    # Use these for patching.
     _conn = _FakeConn()
-    _result = _FakeResult()
+    _result = _FakeResultFailed()
 
+    # Patch anything that requires a real connection.
     mocker.patch("covalent_ssh_plugin.ssh.get_config", side_effect=get_config_mock)
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor._validate_credentials", return_value=True)
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor._client_connect", return_value=(True, _conn))
@@ -143,6 +146,7 @@ async def test_failed_task_handling(mocker):
     mocker.patch("covalent_ssh_plugin.ssh.SSHExecutor.submit_task", return_value=_result)
 
     async with aiofiles.tempfile.NamedTemporaryFile("w") as f:
+
         executor = SSHExecutor(
             username="user",
             hostname="host",
@@ -153,9 +157,10 @@ async def test_failed_task_handling(mocker):
 
         executor.conda_env = None
 
+        # Check that `exit_status != 0` triggers a runtime error.
         with pytest.raises(RuntimeError):
             await executor.run(
-                function=lambda x: x,
+                function=lambda: "Doesn't matter; dummy function.",
                 args=[5],
                 kwargs={},
                 task_metadata={"dispatch_id": -1, "node_id": -1},

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -158,7 +158,7 @@ async def test_client_connect_retry_attempts(mocker):
     mocker.patch("asyncssh.connect", side_effect=_mock_asyncssh_connect)
 
     # Dummy stand-in for ssh key file.
-    with tempfile.NamedTemporaryFile() as f:
+    async with aiofiles.tempfile.NamedTemporaryFile("w") as f:
         ssh_key_file = f.name
 
         executor = SSHExecutor(


### PR DESCRIPTION
Some changes to make the executor more robust.

- Generalizes the `_client_connect()` method a bit, so errors other than `ConnectionRefusedError` can be caught. 
- Moves the `exec` script into a separate file.

(Also addresses issue https://github.com/AgnostiqHQ/covalent-ssh-plugin/issues/61 and covers PR https://github.com/AgnostiqHQ/covalent-ssh-plugin/pull/62 -- both are resolved/included here)

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
